### PR TITLE
Tool Update & Fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,12 +247,12 @@
         <section class="result">
             <h2 class="result__title">結果</h2>
             <div class="result__grid">
-                <div class="result__card is-disabled-anomaly" role="status">
+                <div class="result__card is-hidden-anomaly" role="status">
                     <div class="result__label">通常時</div>
                     <div class="result__value" id="nonCrit">-</div>
                     <span class="copy-icon">📋コピー</span>
                 </div>
-                <div class="result__card is-disabled-anomaly" role="status">
+                <div class="result__card is-hidden-anomaly" role="status">
                     <div class="result__label">会心時</div>
                     <div class="result__value" id="crit">-</div>
                     <span class="copy-icon">📋コピー</span>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
             <div class="header__row">
                 <h1 class="header__title">ゼンレスゾーンゼロ ダメージ計算ツール - ZZZ Dmg Calc. -</h1>
                 <div class="header__meta">
-                    <span class="header__last-update" id="lastUpdate">Last Modified: 2025/10/6</span>
                 </div>
             </div>
         </header>
@@ -132,6 +131,7 @@
                         <label for="attrSelect" class="form__label is-disabled-normal">状態異常補正倍率 [%]</label>
                         <div class="form form--grid">
                             <select id="attrSelect" class="form__input is-disabled-normal">
+                                <option value="">-- 選択してください --</option>
                                 <option value="physical">物理</option>
                                 <option value="electric">電気</option>
                                 <option value="fire">炎</option>
@@ -263,36 +263,39 @@
                     <span class="copy-icon">📋コピー</span>
                 </div>
             </div>
-
-            <!-- トースト通知 -->
-            <div id="toast" class="toast">✅ コピーしました</div>
-
-            <details class="details">
-                <summary class="details__summary">中間倍率を見る</summary>
-                <ul class="kv-list">
-                    <li class="kv"><span class="kv__label">基礎ダメージ</span><span id="base" class="kv__value">-</span></li>
-                    <li class="kv"><span class="kv__label">属性ダメ・与ダメ補正</span><span id="totalBonus"
-                            class="kv__value">-</span></li>
-                    <li class="kv"><span class="kv__label">非会心倍率</span><span id="nonCritMul" class="kv__value">-</span>
-                    </li>
-                    <li class="kv"><span class="kv__label">会心倍率</span><span id="critMul" class="kv__value">-</span></li>
-                    <li class="kv"><span class="kv__label">期待値会心倍率</span><span id="expCritMul"
-                            class="kv__value">-</span></li>
-                    <li class="kv"><span class="kv__label">防御補正</span><span id="defMul" class="kv__value">-</span></li>
-                    <li class="kv"><span class="kv__label">相性補正</span><span id="resiMul" class="kv__value">-</span></li>
-                </ul>
-            </details>
         </section>
+
+        <section class="result result--fixed"></section>
+
+        <!-- トースト通知 -->
+        <div id="toast" class="toast">✅ コピーしました</div>
+
+        <details class="details">
+            <summary class="details__summary">中間倍率を見る</summary>
+            <ul class="kv-list">
+                <li class="kv"><span class="kv__label">基礎ダメージ</span><span id="base" class="kv__value">-</span></li>
+                <li class="kv"><span class="kv__label">属性ダメ・与ダメ補正</span><span id="totalBonus" class="kv__value">-</span>
+                </li>
+                <li class="kv"><span class="kv__label">非会心倍率</span><span id="nonCritMul" class="kv__value">-</span>
+                </li>
+                <li class="kv"><span class="kv__label">会心倍率</span><span id="critMul" class="kv__value">-</span></li>
+                <li class="kv"><span class="kv__label">期待値会心倍率</span><span id="expCritMul" class="kv__value">-</span>
+                </li>
+                <li class="kv"><span class="kv__label">防御補正</span><span id="defMul" class="kv__value">-</span></li>
+                <li class="kv"><span class="kv__label">相性補正</span><span id="resiMul" class="kv__value">-</span></li>
+            </ul>
+        </details>
 
         <!-- フッター -->
         <footer class="footer">
+            <span class="footer__last-modified" id="lastModified">Last Modified: 2025/10/8</span>
             <p class="footer__text">
                 本ツールは非公式の検証用です。ゲーム内の仕様変更により数値が異なる場合があります。<br>
                 Created by <a href="https://www.hoyolab.com/accountCenter/postList?id=144180942"
                     target="_blank">Maybe515</a> ｜
                 Designed by <a href="https://www.hoyolab.com/accountCenter/postList?id=144180942"
                     target="_blank">Maybe515</a> ｜
-                © Fan-made Calculator
+                © 2025 Fan-made Calculator
             </p>
         </footer>
     </main>

--- a/json/agents.json
+++ b/json/agents.json
@@ -2,7 +2,7 @@
     "アンビー・デマラ": { "faction": "邪兎屋", "specialty": "撃破", "attribute": "電気", "image": "anby.webp", "rank": "a" },
     "ビリー・キッド": { "faction": "邪兎屋", "specialty": "強攻", "attribute": "物理", "image": "billy.webp" ,"rank": "a" },
     "ニコ・デマラ": { "faction": "邪兎屋", "specialty": "支援", "attribute": "エーテル", "image": "nicole.webp", "rank": "a" },
-    "猫又": { "faction": "邪兎屋", "specialty": "強攻", "attribute": "物理", "image": "nekomata.webp", "rank": "s" },
+    "猫宮又奈": { "faction": "邪兎屋", "specialty": "強攻", "attribute": "物理", "image": "nekomata.webp", "rank": "s" },
     "アンドー・イワノフ": { "faction": "白祇重工", "specialty": "強攻", "attribute": "電気", "image": "anton.webp", "rank": "a" },
     "ベン・ビガー": { "faction": "白祇重工", "specialty": "防護", "attribute": "炎", "image": "ben.webp", "rank": "a" },
     "グレース・ハワード": { "faction": "白祇重工", "specialty": "異常", "attribute": "電気", "image": "grace.webp", "rank": "s" },

--- a/script.js
+++ b/script.js
@@ -118,6 +118,12 @@
       qa(selector).forEach(el => el.classList.toggle("is-disabled", mode === activeMode));
     toggle(".is-disabled-normal", "normal");
     toggle(".is-disabled-anomaly", "anomaly");
+
+    qa(".is-hidden-anomaly").forEach(el => {
+      el.style.display = (mode === "anomaly") ? "none" : "";
+    });
+
+    document.body.dataset.mode = mode;
   }
 
   // ---------------- Icon/text binding ----------------

--- a/style.css
+++ b/style.css
@@ -408,7 +408,8 @@ select:hover {
 .result__grid {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  /* justify-content: center; */
+  justify-content: flex-start;
   gap: .75rem;
   width: 100%;
 }
@@ -417,6 +418,9 @@ select:hover {
   position: relative;
   cursor: pointer;
   flex: 1 1 220px;
+  /* flex: 0 0 auto; */
+  /* min-width: 220px; */
+  /* max-width: 260px; */
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -442,6 +446,22 @@ select:hover {
   font-size: 1.6rem;
   margin-top: .4rem;
   color: var(--ok);
+}
+
+/* anomaly のときだけ非表示 */
+body[data-mode="anomaly"] .is-hidden-anomaly {
+  display: none !important;
+}
+
+/* anomaly のときだけ左寄せ */
+body[data-mode="anomaly"] .result__grid {
+  justify-content: flex-start;
+}
+
+body[data-mode="anomaly"] .result__card {
+  flex: 0 0 auto;
+  min-width: 220px;
+  max-width: 260px;
 }
 
 /* ---------------- Details ---------------- */
@@ -493,11 +513,15 @@ details[open] .details__summary::before {
 /* ---------------- Footer ---------------- */
 .footer {
   margin-top: 1.5rem;
-  color: var(--muted);
-  font-size: .85rem;
+}
+
+.footer__last-modified  {
+  font-size: 1rem;
 }
 
 .footer__text {
+  font-size: .85rem;
+  color: var(--muted);
   margin: 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ body {
   margin: 0;
   min-height: 100vh;
   max-width: 1600px;
-  padding: 1rem 0 0;
+  padding: 1.25rem 0 0;
   background: var(--bg);
   color: var(--fg);
   font-family: ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetica, Arial;
@@ -56,12 +56,15 @@ body {
   top: 0;
   left: 0;
   width: 100%;
+  height: 50px;
+  display: flex;
+  align-items: center;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(8px) saturate(150%);
   -webkit-backdrop-filter: blur(8px);
 
   border-bottom: 1px solid var(--border);
-  padding: 0 1rem;
+  padding: 0 .75rem;
   z-index: 1000;
 }
 
@@ -74,19 +77,19 @@ body {
 }
 
 .header__title {
-  font-size: 1.4rem;
+  font-size: clamp(1rem, 4vw, 1.4rem);
   font-weight: bold;
+  line-height: 1.2;
   margin: .5rem .2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .header__meta {
   display: flex;
   gap: .8rem;
   font-size: .9rem;
-}
-
-.header__last-update {
-  align-content: center;
 }
 
 /* ---------------- Layout ---------------- */
@@ -97,11 +100,13 @@ body {
 
 .grid {
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
   gap: 1rem;
   padding-bottom: .5rem;
   width: 100%;
+  height: auto;
 }
 
 .grid>.card {
@@ -209,12 +214,13 @@ select:hover {
   display: flex;
   justify-content: space-between;
   align-items: end;
+  gap: .5rem;
   margin-bottom: .5rem;
 }
 
 .mode__toggle {
   display: flex;
-  gap: 1rem;
+  gap: .5rem 1rem;
   flex-wrap: wrap;
 }
 
@@ -312,6 +318,9 @@ select:hover {
   justify-content: flex-end;
   align-items: center;
   color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .kv__value img {
@@ -378,7 +387,6 @@ select:hover {
   opacity: 0;
   transition: opacity .2s ease;
   pointer-events: none;
-  /* アイコン自体はクリックを拾わない */
 }
 
 /* ---------------- Result / Details / Footer 共通 ---------------- */
@@ -393,6 +401,7 @@ select:hover {
 
 /* ---------------- Result ---------------- */
 .result {
+  position: static;
   margin-top: 1.25rem;
 }
 
@@ -520,7 +529,15 @@ a:hover {
 }
 
 /* ---------------- Responsive ---------------- */
-@media (max-width: 600px) {
+/* PC用表示 */
+@media (min-width: 1001px) {
+  .result--fixed {
+    display: none !important;
+  }
+}
+
+/* モバイル用表示 */
+@media (max-width: 1000px) {
   .grid {
     flex-direction: column;
     align-items: stretch;
@@ -532,8 +549,47 @@ a:hover {
     min-width: 0;
   }
 
-  .card--two-column,
-  .form--grid {
+  .result--fixed {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 999;
+    background: rgba(20, 20, 20, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-top: 1px solid var(--border, #444);
+    padding: .5rem 1rem;
+
+    opacity: 0;
+    transform: translateY(20px);
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .result--fixed.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .result__title {
+    margin: 0 0 .3rem;
+  }
+
+  .result__grid {
+    display: flex;
+    justify-content: space-around;
+    gap: .5rem;
+  }
+
+  .result__card {
+    flex: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .card--two-column {
     grid-template-columns: 1fr;
   }
 
@@ -608,6 +664,10 @@ h3 {
   pointer-events: none;
   transition: opacity .3s ease;
   z-index: 2000;
+}
+
+.result--fixed.result--fixed.is-visible~.toast {
+  bottom: 150px;
 }
 
 .toast.show {


### PR DESCRIPTION
## Added
- モバイル表示（Width 1000px以下）で画面下部に"結果"を常に表示する機能を追加

## Changed
- 計算モードが"状態異常ダメージ"の場合、結果を"期待値"のみ表示するように変更

## Fixed
- モバイル表示時、ヘッダーのタイトルが見切れる問題を修正
- キャラ属性と状態異常補正倍率が連動していない問題を修正
- 猫又のみフルネーム表記されていない問題を修正